### PR TITLE
Fix encoding error (issues #3 and #8)

### DIFF
--- a/agb.py
+++ b/agb.py
@@ -145,7 +145,7 @@ def main():
     output_fpath = join(opts.output_dir, HTML_NAME)
     with io.open(TEMPLATE_PATH, 'r', encoding="utf-8") as f: html = f.read()
     html = embed_css_and_scripts(html)
-    with open(output_fpath, 'w') as f:
+    with io.open(output_fpath, 'w', encoding="utf-8") as f:
         f.write(html)
     print('Assembly graph viewer is saved to ' + output_fpath)
 

--- a/agb_src/scripts/utils.py
+++ b/agb_src/scripts/utils.py
@@ -1,4 +1,5 @@
 import math
+import io
 import os
 import re
 import sys
@@ -218,7 +219,7 @@ def embed_css_and_scripts(html):
             line = line_tmpl % rel_fpath
             l_tag_formatted = l_tag % rel_fpath
 
-            with os.io.open(fpath, 'r', encoding="utf-8") as f: contents = f.read()
+            with io.open(fpath, 'r', encoding="utf-8") as f: contents = f.read()
             contents = '\n'.join(' ' * 8 + l for l in contents.split('\n'))
             html = html.replace(line, l_tag_formatted + '\n' + contents + '\n' + r_tag)
 


### PR DESCRIPTION
 * fix typo for `io.open`
 * write HTML output as UTF-8 because template read as UTF-8